### PR TITLE
Do not use a subshell for iw

### DIFF
--- a/ap_
+++ b/ap_
@@ -82,7 +82,7 @@ graph_defs = {
 }
 
 def getStationData():
-    data = subprocess.check_output("iw dev {} station dump".format(interface), shell=True)
+    data = subprocess.check_output(["iw", "dev", interface, "station", "dump"], shell=False)
     
 
     stationRegExp = "Station "


### PR DESCRIPTION
No shell is needed and it avoids the (unlikely) shell injection via strange filenames/device names.